### PR TITLE
fix: persist RefreshAgentLock internal cache keys to summaryClassToKey

### DIFF
--- a/packages/analytics-core/src/Engine/RefreshAgent/RefreshAgentLock.php
+++ b/packages/analytics-core/src/Engine/RefreshAgent/RefreshAgentLock.php
@@ -103,7 +103,7 @@ final class RefreshAgentLock implements ResetInterface
     private function getKey(string $summaryClass): Key
     {
         return $this->summaryClassToKey[$summaryClass]
-            ?? new Key(\sprintf('rekalogika_analytics_%s', $summaryClass));
+            ??= new Key(\sprintf('rekalogika_analytics_%s', $summaryClass));
     }
 
     private function removeKey(string $summaryClass): void


### PR DESCRIPTION
`RefreshAgentLock` never released the key when calling `$this->release($summaryClass)` because the `getKey` method always generated a new key instead of using an internally cached one.