### PR TITLE
fix: show user specified measure in createGroupedBarChart

### DIFF
--- a/packages/analytics-frontend/src/Chart/Implementation/DefaultChartGenerator.php
+++ b/packages/analytics-frontend/src/Chart/Implementation/DefaultChartGenerator.php
@@ -426,16 +426,16 @@ final readonly class DefaultChartGenerator implements ChartGenerator
                     $legendTitle = $this->stringifier->toString($secondDimensionObject->getLabel());
                 }
 
-                $measure = $secondCell->getMeasures()->first();
+                $measureObject = $secondCell->getMeasures()->get($measure);
 
-                if ($measure === null) {
+                if ($measureObject === null) {
                     throw new UnexpectedValueException('Measure not found');
                 }
 
-                $dataSets[$signature]['data'][] = $this->numberifier->toNumber($measure->getValue());
+                $dataSets[$signature]['data'][] = $this->numberifier->toNumber($measureObject->getValue());
 
                 if ($yTitle === null) {
-                    $unit = $measure->getUnit();
+                    $unit = $measureObject->getUnit();
 
                     if ($unit !== null) {
                         $yTitle = \sprintf(


### PR DESCRIPTION
Previously it selected a "random" measure because it used `$secondCell->getMeasures()->first()`. We now use `$secondCell->getMeasures()->get($measure)` to select the measure specified by the user.